### PR TITLE
Spotifyで再生中の曲を教えてくれるようにする

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,3 +8,4 @@ sleep 3
 poetry run python workers/periodic_toot.py &
 poetry run python workers/follow_back.py &
 poetry run python workers/reply.py &
+poetry run python workers/try_toot_spotify_playing.py &

--- a/poetry.lock
+++ b/poetry.lock
@@ -1184,6 +1184,28 @@ files = [
 ]
 
 [[package]]
+name = "spotipy"
+version = "2.23.0"
+description = "A light weight Python library for the Spotify Web API"
+optional = false
+python-versions = "*"
+files = [
+    {file = "spotipy-2.23.0-py2-none-any.whl", hash = "sha256:da850fbf62faaa05912132d2886c293a5fbbe8350d0821e7208a6a2fdd6a0079"},
+    {file = "spotipy-2.23.0-py3-none-any.whl", hash = "sha256:6bf8b963c10d0a3e51037e4baf92e29732dee36b2a1f1b7dcc8cd5771e662a5b"},
+    {file = "spotipy-2.23.0.tar.gz", hash = "sha256:0dfafe08239daae6c16faa68f60b5775d40c4110725e1a7c545ad4c7fb66d4e8"},
+]
+
+[package.dependencies]
+redis = ">=3.5.3"
+requests = ">=2.25.0"
+six = ">=1.15.0"
+urllib3 = ">=1.26.0"
+
+[package.extras]
+doc = ["Sphinx (>=1.5.2)"]
+test = ["mock (==2.0.0)"]
+
+[[package]]
 name = "srsly"
 version = "2.4.7"
 description = "Modern high-performance serialization utilities for Python"
@@ -1458,4 +1480,4 @@ colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\" and python
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4730194f6c3a2fd16df56e816bd27cbb26a86b5164ec266f2572c4ace1b056ff"
+content-hash = "30c0c2f38b23b9a655d7422bc7d52f79af458d7f0ea64df029b8a91d70e971c5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ python-dotenv = "^1.0.0"
 schedule = "^1.2.0"
 rq = "^1.14.1"
 spacy = {extras = ["ja"], version = "^3.6.0"}
+spotipy = "^2.23.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/workers/try_toot_spotify_playing.py
+++ b/workers/try_toot_spotify_playing.py
@@ -1,0 +1,42 @@
+import os
+from zoneinfo import ZoneInfo
+from datetime import datetime, timedelta
+import schedule
+import random
+import time
+
+from yuyutan.jobs.toot_spotify_playing import toot_spotify_playing
+from redis import Redis
+from rq import Queue
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+queue = Queue(connection=Redis(host=os.environ.get("REDIS_HOST", "localhost")))
+
+
+def enqueue() -> None:
+    now = datetime.now(ZoneInfo("Asia/Tokyo"))
+    delta_hours = random.randint(1, 4)
+    next_ = now + timedelta(hours=delta_hours)
+
+    next_minutes = random.randint(0,59)
+
+    next_ = datetime(
+        next_.year, next_.month, next_.day, next_.hour, next_minutes, tzinfo=ZoneInfo("Asia/Tokyo")
+    )
+
+    queue.enqueue_at(next_, toot_spotify_playing)
+
+
+def main() -> None:
+    schedule.every(4).hours.do(enqueue)
+
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/yuyutan/jobs/reply.py
+++ b/yuyutan/jobs/reply.py
@@ -39,6 +39,23 @@ api = Mastodon(
 )
 
 
+def reply_spotify_now_playing(reply_to_id: str, from_account: Account, url: str | None) -> None:
+    if url is None:
+        sentence = "ゆゆ君は何も聞いていないっぽい"
+    else:
+        sentence = f"ゆゆ君はこの曲を聞いているっぽい\n{url}"
+
+    reply_str = f"@{from_account.username} {sentence}"
+    try:
+        api.status_post(
+            reply_str,
+            in_reply_to_id=reply_to_id
+        )
+        logger.info(f"Reply: {reply_str}")
+    except Exception as e:
+        logger.error(e)
+
+
 def reply(reply_to_id: str, from_account: Account, content: str) -> None:
     with open(DATA_DIR / Path("model/model.json"), "r") as fp:
         model_json = fp.read()

--- a/yuyutan/jobs/toot_spotify_playing.py
+++ b/yuyutan/jobs/toot_spotify_playing.py
@@ -1,0 +1,50 @@
+import datetime
+import json
+import os
+from logging import config, getLogger
+from pathlib import Path
+
+from dotenv import load_dotenv
+from mastodon import Mastodon
+from yuyutan.spotify.get_playing import get_playing
+
+DATA_DIR = Path("datas")
+LOG_DIR = Path("logs")
+
+
+with open(Path("logger_config.json"), "r") as fp:
+    logger_config = json.load(fp)
+
+if not LOG_DIR.exists():
+    LOG_DIR.mkdir()
+
+logger_config["handlers"]["fileHandler"]["filename"] = (
+    LOG_DIR / f"{datetime.datetime.now().isoformat()}-{Path(__file__).name}.log"
+)
+
+config.dictConfig(logger_config)
+logger = getLogger(__name__)
+
+
+load_dotenv()
+
+api = Mastodon(
+    api_base_url=os.environ.get("MASTODON_API_BASE_URL"),
+    client_id=os.environ.get("MASTODON_CLIENT_KEY"),
+    client_secret=os.environ.get("MASTODON_CLIENT_SECRET"),
+    access_token=os.environ.get("MASTODON_ACCESS_TOKEN"),
+)
+
+
+def toot_spotify_playing() -> None:
+    url = get_playing()
+
+    if url is None:
+        logger.info("Skipping toot spotify playing")
+    else:
+        sentence = f"ゆゆ君は今この曲を聞いてるよ\n{url}"
+        try:
+            api.toot(sentence)
+            logger.info(f"Toot: {sentence}")
+        except Exception as e:
+            logger.error(e)

--- a/yuyutan/spotify/get_playing.py
+++ b/yuyutan/spotify/get_playing.py
@@ -1,0 +1,24 @@
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+from dotenv import load_dotenv
+
+load_dotenv()
+
+scope = ["user-read-playback-state"]
+
+
+def get_playing() -> str | None:
+    sp = spotipy.Spotify(
+        auth_manager=SpotifyOAuth(
+            scope=scope
+        )
+    )
+    res = sp.current_user_playing_track()
+    try:
+        return str(res["item"]["external_urls"]["spotify"])
+    except Exception:
+        return None
+
+
+if __name__ == "__main__":
+    get_playing()


### PR DESCRIPTION
- Close #4 

## 概要

- 「今何聞いてる」が含まれている時、Spotify APIを叩いて再生中の曲を取得して投稿するようにした